### PR TITLE
Setup: read files in utf-8

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,10 +2,11 @@ import os
 from setuptools import setup, find_packages
 import localized_names as app
 
-
 def read(fname):
     try:
-        return open(os.path.join(os.path.dirname(__file__), fname)).read()
+        return open(os.path.join(os.path.dirname(__file__), fname),
+                    'r',
+                    encoding='utf8').read()
     except IOError:
         return ''
 


### PR DESCRIPTION
Python 3 is less forgiving than python 2 when reading files.

Since README.rst contains non ascii characters, the read will fail.

Forcing the encoding to utf-8 solves this.